### PR TITLE
fix a pointer error when dlist pops up the front element

### DIFF
--- a/dlist.go
+++ b/dlist.go
@@ -110,7 +110,7 @@ func (l *DList[T]) PushBack(val T) {
 	l.length++
 }
 
-// PopFront popups a element from the front of the list.
+// PopFront popups an element from the front of the list.
 func (l *DList[T]) PopFront() T {
 	r, ok := l.TryPopFront()
 	if !ok {
@@ -119,7 +119,7 @@ func (l *DList[T]) PopFront() T {
 	return r
 }
 
-// PopBack popups a element from the back of the list.
+// PopBack popups an element from the back of the list.
 func (l *DList[T]) PopBack() T {
 	r, ok := l.TryPopBack()
 	if !ok {
@@ -128,26 +128,26 @@ func (l *DList[T]) PopBack() T {
 	return r
 }
 
-// TryPopFront tries to popup a element from the front of the list.
+// TryPopFront tries to pop up an element from the front of the list.
 func (l *DList[T]) TryPopFront() (T, bool) {
 	var val T
-	if l.length == 0 {
+	if l.IsEmpty() {
 		return val, false
 	}
 	node := l.head.next
 	val = node.value
 	l.head.next = node.next
-	l.head.prev = l.head
+	l.head.next.prev = l.head
 	node.prev = nil
 	node.next = nil
 	l.length--
 	return val, true
 }
 
-// TryPopBack tries to popup a element from the back of the list.
+// TryPopBack tries to pop up an element from the back of the list.
 func (l *DList[T]) TryPopBack() (T, bool) {
 	var val T
-	if l.length == 0 {
+	if l.IsEmpty() {
 		return val, false
 	}
 	node := l.head.prev
@@ -162,7 +162,7 @@ func (l *DList[T]) TryPopBack() (T, bool) {
 
 // ForEach iterate the list, apply each element to the cb callback function.
 func (l *DList[T]) ForEach(cb func(val T)) {
-	if l.head == nil {
+	if l.IsEmpty() {
 		return
 	}
 	for n := l.head.next; n != l.head; n = n.next {
@@ -173,7 +173,7 @@ func (l *DList[T]) ForEach(cb func(val T)) {
 // ForEachIf iterate the list, apply each element to the cb callback function,
 // stop if cb returns false.
 func (l *DList[T]) ForEachIf(cb func(val T) bool) {
-	if l.head == nil {
+	if l.IsEmpty() {
 		return
 	}
 	for n := l.head.next; n != l.head; n = n.next {
@@ -185,7 +185,7 @@ func (l *DList[T]) ForEachIf(cb func(val T) bool) {
 
 // ForEachMutable iterate the list, apply pointer of each element to the cb callback function.
 func (l *DList[T]) ForEachMutable(cb func(val *T)) {
-	if l.head == nil {
+	if l.IsEmpty() {
 		return
 	}
 	for n := l.head.next; n != l.head; n = n.next {
@@ -196,7 +196,7 @@ func (l *DList[T]) ForEachMutable(cb func(val *T)) {
 // ForEachMutableIf iterate the list, apply pointer of each element to the cb callback function,
 // stop if cb returns false.
 func (l *DList[T]) ForEachMutableIf(cb func(val *T) bool) {
-	if l.head == nil {
+	if l.IsEmpty() {
 		return
 	}
 	for n := l.head.next; n != l.head; n = n.next {

--- a/dlist_test.go
+++ b/dlist_test.go
@@ -66,22 +66,36 @@ func Test_DList_PushBack(t *testing.T) {
 }
 
 func Test_DList_PopFront(t *testing.T) {
-	l := DListOf(1, 2)
+	l := DListOf(1, 2, 3, 4)
 	expectEq(t, l.PopFront(), 1)
+	expectEq(t, l.PopFront(), 2)
+
 	n, ok := l.TryPopFront()
-	expectEq(t, n, 2)
+	expectEq(t, n, 3)
 	expectTrue(t, ok)
+
+	n, ok = l.TryPopBack()
+	expectEq(t, n, 4)
+	expectTrue(t, ok)
+
 	n, ok = l.TryPopFront()
 	expectFalse(t, ok)
 	expectPanic(t, func() { l.PopFront() })
 }
 
 func Test_DList_PopBack(t *testing.T) {
-	l := DListOf(1, 2)
-	expectEq(t, l.PopBack(), 2)
+	l := DListOf(1, 2, 3, 4)
+	expectEq(t, l.PopBack(), 4)
+	expectEq(t, l.PopBack(), 3)
+
 	n, ok := l.TryPopBack()
 	expectTrue(t, ok)
+	expectEq(t, n, 2)
+
+	n, ok = l.TryPopFront()
+	expectTrue(t, ok)
 	expectEq(t, n, 1)
+
 	n, ok = l.TryPopBack()
 	expectFalse(t, ok)
 	expectPanic(t, func() { l.PopBack() })
@@ -90,8 +104,11 @@ func Test_DList_PopBack(t *testing.T) {
 func Test_DList_PushBack_PopFront(t *testing.T) {
 	l := DList[int]{}
 	l.PushBack(1)
+	l.PushBack(2)
+
 	v := l.PopFront()
 	expectEq(t, v, 1)
+	expectEq(t, l.PopFront(), 2)
 }
 
 func Test_DList_PushBack_PopBack(t *testing.T) {


### PR DESCRIPTION
1. fix the typo in the dlist
2. use a uniform way to determine if dlist is empty
3. fix a pointer error when dlist pops up the front element
