### PR TITLE
improve the code robustness of slist

### DIFF
--- a/slist.go
+++ b/slist.go
@@ -40,11 +40,17 @@ func (l *SList[T]) Clear() {
 
 // Front returns the first element in the list.
 func (l *SList[T]) Front() T {
+	if l.IsEmpty() {
+		panic("!IsEmpty")
+	}
 	return l.head.value
 }
 
 // Back returns the last element in the list.
 func (l *SList[T]) Back() T {
+	if l.IsEmpty() {
+		panic("!IsEmpty")
+	}
 	return l.tail.value
 }
 
@@ -74,14 +80,16 @@ func (l *SList[T]) PushBack(v T) {
 // PopFront popups an element from the front of the list.
 // The list must be non-empty!
 func (l *SList[T]) PopFront() T {
-	node := l.head
-	if node != nil {
-		l.head = node.next
-		if l.head == nil {
-			l.tail = nil
-		}
-		l.length--
+	if l.IsEmpty() {
+		panic("!IsEmpty")
 	}
+
+	node := l.head
+	l.head = node.next
+	if l.head == nil {
+		l.tail = nil
+	}
+	l.length--
 	return node.value
 }
 
@@ -166,7 +174,7 @@ type sListIterator[T any] struct {
 	node *sListNode[T]
 }
 
-func (it sListIterator[T]) IsNotEnd() bool {
+func (it *sListIterator[T]) IsNotEnd() bool {
 	return it.node != nil
 }
 
@@ -174,11 +182,11 @@ func (it *sListIterator[T]) MoveToNext() {
 	it.node = it.node.next
 }
 
-func (it sListIterator[T]) Value() T {
+func (it *sListIterator[T]) Value() T {
 	return it.node.value
 }
 
-func (it sListIterator[T]) Pointer() *T {
+func (it *sListIterator[T]) Pointer() *T {
 	return &it.node.value
 }
 

--- a/slist_test.go
+++ b/slist_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func Test_DList_Interface(t *testing.T) {
+func Test_SList_Interface(t *testing.T) {
 	sl := SList[int]{}
 	_ = Container(&sl)
 }
@@ -15,6 +15,44 @@ func Test_SList_Clean(t *testing.T) {
 	sl.Clear()
 	expectTrue(t, sl.IsEmpty())
 	expectEq(t, sl.Len(), 0)
+}
+
+func Test_SList_Front(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		sl := SList[int]{}
+		expectPanic(t, func() { sl.Front() })
+	})
+
+	t.Run("normal", func(t *testing.T) {
+		sl := SList[int]{}
+		sl.PushFront(1)
+		expectEq(t, sl.Front(), 1)
+
+		sl.PushBack(2)
+		expectEq(t, sl.Front(), 1)
+
+		sl.PushFront(3)
+		expectEq(t, sl.Front(), 3)
+	})
+}
+
+func Test_SList_Back(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		sl := SList[int]{}
+		expectPanic(t, func() { sl.Back() })
+	})
+
+	t.Run("normal", func(t *testing.T) {
+		sl := SList[int]{}
+		sl.PushBack(1)
+		expectEq(t, sl.Back(), 1)
+
+		sl.PushFront(2)
+		expectEq(t, sl.Back(), 1)
+
+		sl.PushBack(3)
+		expectEq(t, sl.Back(), 3)
+	})
 }
 
 func Test_SList_PushFront(t *testing.T) {
@@ -38,6 +76,8 @@ func Test_SList_PushBack(t *testing.T) {
 
 func Test_SList_PopFront(t *testing.T) {
 	sl := SList[int]{}
+	expectPanic(t, func() { sl.PopFront() })
+
 	sl.PushFront(1)
 	sl.PushFront(2)
 	expectEq(t, sl.PopFront(), 2)


### PR DESCRIPTION
1. use explicit panic instead of runtime errors such as null pointers
2. add test cases for SList.Front and SList.Back
3. sListIterator uniformly uses the same type of receiver(Go recommended)